### PR TITLE
Appends identifier to span names

### DIFF
--- a/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -1,9 +1,22 @@
 defmodule Tesla.Middleware.OpenTelemetry do
   @behaviour Tesla.Middleware
 
-  def call(env, next, _options) do
+  def call(env, next, options \\ []) do
     env
+    |> maybe_put_span_name(options[:span_name])
     |> Tesla.put_headers(:otel_propagator_text_map.inject([]))
     |> Tesla.run(next)
+  end
+
+  defp maybe_put_span_name(env, nil), do: env
+
+  defp maybe_put_span_name(env, span_name) when is_binary(span_name) do
+    case env.opts[:span_name] do
+      nil ->
+        Tesla.put_opt(env, :span_name, span_name)
+
+      _ ->
+        env
+    end
   end
 end

--- a/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -18,9 +18,18 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
              Tesla.Middleware.OpenTelemetry.call(
                %Tesla.Env{url: ""},
                [],
-               "http://example.com"
+               []
              )
 
     assert is_binary(traceparent)
+  end
+
+  test "Puts the `span_name` option into Tesla.Env's `opts`" do
+    assert {:ok, env} =
+             Tesla.Middleware.OpenTelemetry.call(%Tesla.Env{url: ""}, [],
+               span_name: "external-service"
+             )
+
+    assert env.opts[:span_name] == "external-service"
   end
 end


### PR DESCRIPTION
Add option to append text to span names, making it easier to identify external calls in the span tree.