### PR TITLE
Don't flag Spans as errors for expected status codes

### DIFF
--- a/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -1,9 +1,35 @@
 defmodule Tesla.Middleware.OpenTelemetry do
+  @moduledoc """
+  Injects tracing header to external requests and configures some
+  span's behaviours.
+
+  ## Options
+
+    * `:span_name` - appends the given string to the generated span's name of
+      _HTTP + verb_.
+    * `:non_error_statuses` - configures expected HTTP response status errors,
+      usually >= 400, to not mark spans as errors. E.g., fetching location
+      coordinates.
+
+  ## Examples
+
+      middlewares = [
+        ...,
+        {Tesla.Middleware.OpenTelemetry, span_name: "my-external-service"}
+      ]
+
+
+      middlewares = [
+        ...,
+        {Tesla.Middleware.OpenTelemetry, non_error_statuses: [404]}
+      ]
+  """
   @behaviour Tesla.Middleware
 
   def call(env, next, options \\ []) do
     env
     |> maybe_put_span_name(options[:span_name])
+    |> maybe_put_non_error_statuses(options[:non_error_statuses])
     |> Tesla.put_headers(:otel_propagator_text_map.inject([]))
     |> Tesla.run(next)
   end
@@ -14,6 +40,18 @@ defmodule Tesla.Middleware.OpenTelemetry do
     case env.opts[:span_name] do
       nil ->
         Tesla.put_opt(env, :span_name, span_name)
+
+      _ ->
+        env
+    end
+  end
+
+  defp maybe_put_non_error_statuses(env, nil), do: env
+
+  defp maybe_put_non_error_statuses(env, non_error_statuses) when is_list(non_error_statuses) do
+    case env.opts[:non_error_statuses] do
+      nil ->
+        Tesla.put_opt(env, :non_error_statuses, non_error_statuses)
 
       _ ->
         env

--- a/lib/opentelemetry_tesla.ex
+++ b/lib/opentelemetry_tesla.ex
@@ -71,9 +71,20 @@ defmodule OpentelemetryTesla do
     )
   end
 
-  def handle_stop(_event, _measurements, %{env: %Tesla.Env{status: status}} = metadata, _config)
+  def handle_stop(
+        _event,
+        _measurements,
+        %{env: %Tesla.Env{status: status, opts: opts}} = metadata,
+        _config
+      )
       when status > 400 do
-    end_span(metadata, :error)
+    non_error_statuses = Keyword.get(opts, :non_error_statuses, [])
+
+    if status in non_error_statuses do
+      end_span(metadata, :ok)
+    else
+      end_span(metadata, :error)
+    end
   end
 
   def handle_stop(

--- a/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -32,4 +32,13 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
 
     assert env.opts[:span_name] == "external-service"
   end
+
+  test "Puts the `non_error_statuses` option into Tesla.Env's `opts`" do
+    assert {:ok, env} =
+             Tesla.Middleware.OpenTelemetry.call(%Tesla.Env{url: ""}, [],
+               non_error_statuses: [404]
+             )
+
+    assert env.opts[:non_error_statuses] == [404]
+  end
 end


### PR DESCRIPTION
Sometimes a 404 or 422 response is expected (e.g., locator responses). We prefer to not flag spans as errors in these cases.